### PR TITLE
Avoid integer overflow when computing maximum precision

### DIFF
--- a/src/mlmpfr_stubs.c
+++ b/src/mlmpfr_stubs.c
@@ -39,7 +39,7 @@ precision_in_range (value prec)
   int p = Int_val (prec);
 
   if (p <= Int_val (caml_mpfr_prec_min ())
-      || p >= Int_val (caml_mpfr_prec_max ()))
+      || p >= Unsigned_int_val (caml_mpfr_prec_max ()))
     caml_raise_with_arg (*caml_named_value ("precision range exception"),
                          Val_int (p));
 }


### PR DESCRIPTION
I am in the process of adding mlmpfr to the Fedora Linux distribution, for use by why3.  The initial build attempt succeeded on all 64-bit platforms and failed on all 32-bit platforms.  It turns out that `Int_val (caml_mpfr_prec_max ())` is equal to -257 on 32-bit platforms.  Decoding the maximum precision as an unsigned integer gives the expected result on both 32-bit and 64-bit platforms.