### PR TITLE
Do not run the testsuite with parallel jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           eval $(opam env --switch=${{ matrix.ocaml }})
           dune build @install --profile dev
-          dune build @runtest --profile dev
+          dune build @runtest --profile dev -j1
           dune build @doc
           dune install
           # LD_LIBRARY_PATH is not exported by dune for executables
@@ -84,7 +84,7 @@ jobs:
         run: |
           eval $(opam env --switch=${{ matrix.ocaml }})
           dune build @install --profile dev
-          dune build @runtest --profile dev
+          dune build @runtest --profile dev -j1
           dune build @doc
           dune install
           # LD_LIBRARY_PATH is not exported by dune for executables


### PR DESCRIPTION
This is an attempt to hide the spurious failure that I can reproduce
locally anymore. Looks like a dependency issue.

FTR (Actions #36):

```
conversionfunctions testsuite/conversion/conversionfunctions.output (exit 2)
(cd _build/default/testsuite/conversion && ./conversionfunctions.exe fpif_import.data) > _build/default/testsuite/conversion/conversionfunctions.output
Fatal error: exception Sys_error("fpif_export.output: Permission denied")
```