### PR TITLE
Use dune-configurator to locate mpfr

### DIFF
--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -1,0 +1,24 @@
+module C = Configurator.V1
+
+let cflags = ["-O2"; "-Wall"; "-Wextra"; "-fPIC"]
+
+let () =
+  C.main ~name:"discover-mpfr" (fun c ->
+    let default : C.Pkg_config.package_conf =
+      { libs   = ["-lmpfr"]
+      ; cflags = cflags
+      }
+    in
+    let conf =
+      match C.Pkg_config.get c with
+  | None -> default
+  | Some pc ->
+      match (C.Pkg_config.query pc ~package:"mpfr") with
+     | None -> default
+     | Some deps -> deps
+    in
+
+
+    C.Flags.write_sexp "c_flags.sexp" (List.concat [cflags; conf.cflags]);
+    C.Flags.write_sexp "c_library_flags.sexp" conf.libs)
+

--- a/src/config/dune
+++ b/src/config/dune
@@ -1,0 +1,3 @@
+(executable
+ (name discover)
+ (libraries dune-configurator))

--- a/src/dune
+++ b/src/dune
@@ -3,5 +3,9 @@
  (public_name mlmpfr)
  (wrapped false)
  (modules mlmpfr)
- (foreign_stubs (language c) (names mlmpfr_stubs) (flags -O2 -Wall -Wextra -fPIC))
- (c_library_flags -lmpfr))
+ (foreign_stubs (language c) (names mlmpfr_stubs) (flags (:include c_flags.sexp)))
+ (c_library_flags (:include c_library_flags.sexp)))
+
+(rule
+ (targets c_flags.sexp c_library_flags.sexp)
+ (action  (run ./config/discover.exe)))


### PR DESCRIPTION
This extends support to many systems, including macos with homebrew and macports.

This is not fixing the tests not the manual compatibility check.
I'll fix the latter soon, but I don't have time to restructure the tests.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>