### PR TITLE
Make `sign` a ternary value

### DIFF
--- a/src/mlmpfr.ml
+++ b/src/mlmpfr.ml
@@ -22,7 +22,7 @@ type mpfr_rnd_t =
   | Away_From_Zero
   | Faithful
 
-type sign = Positive | Negative
+type sign = Positive | Negative | Zero
 type mpfr_prec_t = int
 type mpfr_exp_t = int
 type mpfr_t
@@ -664,7 +664,7 @@ external max :
 
 external get_exp : mpfr_float -> mpfr_prec_t = "caml_mpfr_get_exp"
 external set_exp : mpfr_float -> mpfr_exp_t -> mpfr_float = "caml_mpfr_set_exp"
-external signbit : mpfr_float -> sign = "caml_mpfr_signbit"
+external signbit : mpfr_float -> bool = "caml_mpfr_signbit"
 
 external setsign :
   ?rnd:mpfr_rnd_t -> ?prec:mpfr_prec_t -> mpfr_float -> sign -> mpfr_float
@@ -748,9 +748,7 @@ let get_formatted_str ?(rnd = To_Nearest) ?(base = 10) ?(size = 0) ?(ktz = true)
         (String.concat "" (String.split_on_char '@' significand))
     in
     (* if NaN, add the bitsign since get_str doesn't return the sign of NaNs *)
-    (if nan_or_inf == "nan" then
-     match signbit x with Positive -> "" | Negative -> "-"
-    else "")
+    (if nan_or_inf == "nan" then if signbit x then "-" else "" else "")
     ^ nan_or_inf
   else
     let mantissa =
@@ -760,10 +758,10 @@ let get_formatted_str ?(rnd = To_Nearest) ?(base = 10) ?(size = 0) ?(ktz = true)
     Printf.sprintf "%s%s%s%c%+03d"
       (if neg then String.sub mantissa 0 2 else Char.escaped mantissa.[0])
       (if
-       (neg && String.length mantissa == 2)
-       || (neg == false && String.length mantissa == 1)
-      then ""
-      else ".")
+         (neg && String.length mantissa == 2)
+         || (neg == false && String.length mantissa == 1)
+       then ""
+       else ".")
       (String.sub mantissa
          (if neg then 2 else 1)
          (String.length mantissa - if neg then 2 else 1))

--- a/src/mlmpfr.ml
+++ b/src/mlmpfr.ml
@@ -271,7 +271,7 @@ external inf_p : mpfr_float -> bool = "caml_mpfr_inf_p"
 external number_p : mpfr_float -> bool = "caml_mpfr_number_p"
 external zero_p : mpfr_float -> bool = "caml_mpfr_zero_p"
 external regular_p : mpfr_float -> bool = "caml_mpfr_regular_p"
-external sgn : mpfr_float -> sign = "caml_mpfr_sgn"
+external sgn : mpfr_float -> int = "caml_mpfr_sgn"
 external greater_p : mpfr_float -> mpfr_float -> bool = "caml_mpfr_greater_p"
 
 external greaterequal_p : mpfr_float -> mpfr_float -> bool

--- a/src/mlmpfr.ml
+++ b/src/mlmpfr.ml
@@ -271,7 +271,7 @@ external inf_p : mpfr_float -> bool = "caml_mpfr_inf_p"
 external number_p : mpfr_float -> bool = "caml_mpfr_number_p"
 external zero_p : mpfr_float -> bool = "caml_mpfr_zero_p"
 external regular_p : mpfr_float -> bool = "caml_mpfr_regular_p"
-external sgn : mpfr_float -> int = "caml_mpfr_sgn"
+external sgn : mpfr_float -> sign = "caml_mpfr_sgn"
 external greater_p : mpfr_float -> mpfr_float -> bool = "caml_mpfr_greater_p"
 
 external greaterequal_p : mpfr_float -> mpfr_float -> bool

--- a/src/mlmpfr.ml
+++ b/src/mlmpfr.ml
@@ -758,8 +758,8 @@ let get_formatted_str ?(rnd = To_Nearest) ?(base = 10) ?(size = 0) ?(ktz = true)
     Printf.sprintf "%s%s%s%c%+03d"
       (if neg then String.sub mantissa 0 2 else Char.escaped mantissa.[0])
       (if
-         (neg && String.length mantissa == 2)
-         || (neg == false && String.length mantissa == 1)
+        (neg && String.length mantissa == 2)
+        || (neg == false && String.length mantissa == 1)
        then ""
        else ".")
       (String.sub mantissa

--- a/src/mlmpfr.mli
+++ b/src/mlmpfr.mli
@@ -405,7 +405,7 @@ val zero_p : mpfr_float -> bool
 val regular_p : mpfr_float -> bool
 (** Its a regular number (i.e., neither NaN, nor an infinity nor zero). *)
 
-val sgn : mpfr_float -> int
+val sgn : mpfr_float -> sign
 (** Return the sign of a [mpfr_float] number. If the operand is NaN, set the
     [Erange] flag and return zero.*)
 

--- a/src/mlmpfr.mli
+++ b/src/mlmpfr.mli
@@ -405,7 +405,7 @@ val zero_p : mpfr_float -> bool
 val regular_p : mpfr_float -> bool
 (** Its a regular number (i.e., neither NaN, nor an infinity nor zero). *)
 
-val sgn : mpfr_float -> sign
+val sgn : mpfr_float -> int
 (** Return the sign of a [mpfr_float] number. *)
 
 val greater_p : mpfr_float -> mpfr_float -> bool

--- a/src/mlmpfr.mli
+++ b/src/mlmpfr.mli
@@ -70,7 +70,7 @@ exception Invalid_integer_input of int
 (** Raised if mlmpfr tries to call a mpfr_*_ui function with a negative
     integer. *)
 
-type sign = Positive | Negative
+type sign = Positive | Negative | Zero
 
 type mpfr_t
 (** Binding to C MPFR {e
@@ -880,8 +880,8 @@ val get_exp : mpfr_float -> int
 val set_exp : mpfr_float -> int -> mpfr_float
 (** Return a fresh [mpfr_float] from input with new precision. *)
 
-val signbit : mpfr_float -> sign
-(** Return the sign of a [mpfr_float]. *)
+val signbit : mpfr_float -> bool
+(** Return true if the signbit of a [mpfr_float] is set. *)
 
 val setsign : ?rnd:mpfr_rnd_t -> ?prec:int -> mpfr_float -> sign -> mpfr_float
 (** [Mlmpfr.setsign x s ~rnd:r] returns a fresh copy of [x] with the sign [s],

--- a/src/mlmpfr.mli
+++ b/src/mlmpfr.mli
@@ -406,7 +406,8 @@ val regular_p : mpfr_float -> bool
 (** Its a regular number (i.e., neither NaN, nor an infinity nor zero). *)
 
 val sgn : mpfr_float -> int
-(** Return the sign of a [mpfr_float] number. *)
+(** Return the sign of a [mpfr_float] number. If the operand is NaN, set the
+    [Erange] flag and return zero.*)
 
 val greater_p : mpfr_float -> mpfr_float -> bool
 (** Operator [>] in MPFR syntax style. *)

--- a/src/mlmpfr.mli
+++ b/src/mlmpfr.mli
@@ -407,7 +407,7 @@ val regular_p : mpfr_float -> bool
 
 val sgn : mpfr_float -> sign
 (** Return the sign of a [mpfr_float] number. If the operand is NaN, set the
-    [Erange] flag and return zero.*)
+    [Erange] flag and return [Zero].*)
 
 val greater_p : mpfr_float -> mpfr_float -> bool
 (** Operator [>] in MPFR syntax style. *)
@@ -623,7 +623,9 @@ val lngamma : ?rnd:mpfr_rnd_t -> ?prec:int -> mpfr_float -> mpfr_float
 
 val lgamma : ?rnd:mpfr_rnd_t -> ?prec:int -> mpfr_float -> mpfr_float * sign
 (** Return the logarithm of the absolute value of the Gamma function and the
-    sign of the Gamma function on a [mpfr_float]. *)
+    sign of the Gamma function on a [mpfr_float]. When [x] is NaN, −Inf or
+    a negative integer, the sign is [Zero] is undefined; when [x] is +0.0,
+    the sign is [Positive]; and when [x] is -0.0, the sign is [Negative]. *)
 
 val digamma : ?rnd:mpfr_rnd_t -> ?prec:int -> mpfr_float -> mpfr_float
 (** Return the Digamma (sometimes also called Psi) function on a

--- a/src/mlmpfr_stubs.c
+++ b/src/mlmpfr_stubs.c
@@ -886,7 +886,7 @@ CAMLprim value
 caml_mpfr_sgn (value op)
 {
   CAMLparam1 (op);
-  CAMLreturn (Val_int (mpfr_sgn (MPFR_val2 (op))));
+  CAMLreturn (val_sign( mpfr_sgn (MPFR_val2 (op))));
 }
 
 CAMLprim value
@@ -1874,7 +1874,6 @@ CAMLprim value
 caml_mpfr_signbit (value op)
 {
   CAMLparam1 (op);
-
   CAMLreturn (mpfr_signbit (MPFR_val2 (op)));
 }
 

--- a/src/mlmpfr_stubs.c
+++ b/src/mlmpfr_stubs.c
@@ -886,7 +886,7 @@ CAMLprim value
 caml_mpfr_sgn (value op)
 {
   CAMLparam1 (op);
-  CAMLreturn (val_sign( mpfr_sgn (MPFR_val2 (op))));
+  CAMLreturn (val_sign (mpfr_sgn (MPFR_val2 (op))));
 }
 
 CAMLprim value
@@ -1282,14 +1282,14 @@ caml_mpfr_lgamma (value rnd, value prec, value op)
   ter = mpfr_lgamma (MPFR_val (rop), &signp, MPFR_val2 (op), rnd_val_opt (rnd));
 
   // sign is undefined when rop is NaN, -Inf, or a negative integer
-  if ( mpfr_nan_p (MPFR_val2 (op)) ||
-       ( mpfr_sgn (MPFR_val2 (op)) < 0 && (mpfr_inf_p (MPFR_val2 (op)) || mpfr_integer_p (MPFR_val2 (op))) ))
+  if (mpfr_nan_p (MPFR_val2 (op))
+      || (mpfr_sgn (MPFR_val2 (op)) < 0
+          && (mpfr_inf_p (MPFR_val2 (op)) || mpfr_integer_p (MPFR_val2 (op)))))
     signp = 0;
 
   tval = val_ter (ter);
   sval = val_some (tval);
-  CAMLreturn (
-    caml_tuple2 (mpfr_float (rop, sval), val_sign (signp)));
+  CAMLreturn (caml_tuple2 (mpfr_float (rop, sval), val_sign (signp)));
 }
 
 CAMLprim value

--- a/src/mlmpfr_stubs.c
+++ b/src/mlmpfr_stubs.c
@@ -1281,6 +1281,11 @@ caml_mpfr_lgamma (value rnd, value prec, value op)
   rop = caml_mpfr_init2_opt (prec);
   ter = mpfr_lgamma (MPFR_val (rop), &signp, MPFR_val2 (op), rnd_val_opt (rnd));
 
+  // sign is undefined when rop is NaN, -Inf, or a negative integer
+  if ( mpfr_nan_p (MPFR_val2 (op)) ||
+       ( mpfr_sgn (MPFR_val2 (op)) < 0 && (mpfr_inf_p (MPFR_val2 (op)) || mpfr_integer_p (MPFR_val2 (op))) ))
+    signp = 0;
+
   tval = val_ter (ter);
   sval = val_some (tval);
   CAMLreturn (

--- a/src/mlmpfr_stubs.c
+++ b/src/mlmpfr_stubs.c
@@ -886,7 +886,7 @@ CAMLprim value
 caml_mpfr_sgn (value op)
 {
   CAMLparam1 (op);
-  CAMLreturn (val_sign (mpfr_sgn (MPFR_val2 (op))));
+  CAMLreturn (Val_int (mpfr_sgn (MPFR_val2 (op))));
 }
 
 CAMLprim value

--- a/src/mlmpfr_stubs.c
+++ b/src/mlmpfr_stubs.c
@@ -1869,13 +1869,8 @@ CAMLprim value
 caml_mpfr_signbit (value op)
 {
   CAMLparam1 (op);
-  int s;
 
-  s = mpfr_signbit (MPFR_val2 (op));
-  if (s == 0)
-    CAMLreturn (Val_int (0));
-  else
-    CAMLreturn (Val_int (1));
+  CAMLreturn (mpfr_signbit (MPFR_val2 (op)));
 }
 
 CAMLprim value

--- a/src/mlmpfr_stubs.c
+++ b/src/mlmpfr_stubs.c
@@ -1874,7 +1874,7 @@ CAMLprim value
 caml_mpfr_signbit (value op)
 {
   CAMLparam1 (op);
-  CAMLreturn (mpfr_signbit (MPFR_val2 (op)));
+  CAMLreturn (Val_bool (mpfr_signbit (MPFR_val2 (op))));
 }
 
 CAMLprim value

--- a/src/mlmpfr_stubs.h
+++ b/src/mlmpfr_stubs.h
@@ -149,6 +149,8 @@ sign_val (value s)
       return 1;
     case 1:
       return -1;
+    case 2:
+      return 0;
     default:
       caml_failwith (__FUNCTION__);
     }
@@ -170,10 +172,12 @@ val_sign (int s)
 {
   CAMLparam0 ();
 
-  if (s >= 0)
+  if (s > 0)
     CAMLreturn (Val_int (0));
-  else
+  else if (s < 0)
     CAMLreturn (Val_int (1));
+  else
+    CAMLreturn (Val_int (2));
 }
 
 static int

--- a/testsuite/comparisonfunctions.c
+++ b/testsuite/comparisonfunctions.c
@@ -35,7 +35,7 @@ void all (mpfr_t op1, mpfr_t op2)
   printf("%s\n", mpfr_number_p (op1) != 0 ? "true" : "false");
   printf("%s\n", mpfr_zero_p (op1) != 0 ? "true" : "false");
   printf("%s\n", mpfr_regular_p (op1) != 0 ? "true" : "false");
-  printf("%s\n", mpfr_sgn (op1) >= 0 ? "Positive" : "Negative");
+  printf("%d\n", mpfr_sgn (op1));
   printf("%s\n", mpfr_greater_p (op1, op2) != 0 ? "true" : "false");
   printf("%s\n", mpfr_greaterequal_p (op1, op2) != 0 ? "true" : "false");
   printf("%s\n", mpfr_less_p (op1, op2) != 0 ? "true" : "false");

--- a/testsuite/comparisonfunctions.c
+++ b/testsuite/comparisonfunctions.c
@@ -35,7 +35,7 @@ void all (mpfr_t op1, mpfr_t op2)
   printf("%s\n", mpfr_number_p (op1) != 0 ? "true" : "false");
   printf("%s\n", mpfr_zero_p (op1) != 0 ? "true" : "false");
   printf("%s\n", mpfr_regular_p (op1) != 0 ? "true" : "false");
-  printf("%d\n", mpfr_sgn (op1));
+  printf("%s\n", mpfr_sgn (op1) > 0 ? "Positive" : ( mpfr_sgn (op1) < 0 ? "Negative" : "Zero" ) );
   printf("%s\n", mpfr_greater_p (op1, op2) != 0 ? "true" : "false");
   printf("%s\n", mpfr_greaterequal_p (op1, op2) != 0 ? "true" : "false");
   printf("%s\n", mpfr_less_p (op1, op2) != 0 ? "true" : "false");

--- a/testsuite/comparisonfunctions.ml
+++ b/testsuite/comparisonfunctions.ml
@@ -29,8 +29,7 @@ let all op1 op2 =
   printf "%b\n" (M.number_p op1);
   printf "%b\n" (M.zero_p op1);
   printf "%b\n" (M.regular_p op1);
-  printf "%s\n"
-    (match M.sgn op1 with M.Positive -> "Positive" | M.Negative -> "Negative");
+  printf "%d\n" (M.sgn op1);
   printf "%b\n" (M.greater_p op1 op2);
   printf "%b\n" (M.greaterequal_p op1 op2);
   printf "%b\n" (M.less_p op1 op2);

--- a/testsuite/comparisonfunctions.ml
+++ b/testsuite/comparisonfunctions.ml
@@ -29,7 +29,11 @@ let all op1 op2 =
   printf "%b\n" (M.number_p op1);
   printf "%b\n" (M.zero_p op1);
   printf "%b\n" (M.regular_p op1);
-  printf "%d\n" (M.sgn op1);
+  printf "%s\n"
+    (match M.sgn op1 with
+    | Positive -> "Positive"
+    | Negative -> "Negative"
+    | Zero -> "Zero");
   printf "%b\n" (M.greater_p op1 op2);
   printf "%b\n" (M.greaterequal_p op1 op2);
   printf "%b\n" (M.less_p op1 op2);

--- a/testsuite/initializationfunctions.ml
+++ b/testsuite/initializationfunctions.ml
@@ -37,7 +37,6 @@ let _ =
   printf "%s\n" (rounding_to_string x);
   printf "%d\n" (M.get_prec x);
   (* Should not raise Precision_range exception *)
-  let _ = M.make_zero ~prec:M.mpfr_prec_min M.Positive in
-  ();
+  let _ = M.make_zero ~prec:M.mpfr_prec_min M.Positive in ();
   Gc.full_major ()
 (* garbage collector full major *)

--- a/testsuite/initializationfunctions.ml
+++ b/testsuite/initializationfunctions.ml
@@ -37,6 +37,7 @@ let _ =
   printf "%s\n" (rounding_to_string x);
   printf "%d\n" (M.get_prec x);
   (* Should not raise Precision_range exception *)
-  let _ = M.make_zero ~prec:M.mpfr_prec_min M.Positive in ();
+  let _ = M.make_zero ~prec:M.mpfr_prec_min M.Positive in
+  ();
   Gc.full_major ()
 (* garbage collector full major *)

--- a/testsuite/miscellaneousfunctions.ml
+++ b/testsuite/miscellaneousfunctions.ml
@@ -25,7 +25,7 @@ let all op1 op2 exp =
   printf "%s\n" (M.get_formatted_str (M.max op1 op2));
   printf "%d\n" (M.get_exp op1);
   printf "%d\n" (M.get_exp (M.set_exp op1 exp));
-  printf "%s\n" (if M.signbit op1 then "Positive" else "Negative");
+  printf "%s\n" (if M.signbit op1 then "Negative" else "Positive");
   printf "%s\n" (M.get_formatted_str (M.copysign op1 op2));
   printf "%s\n" (M.get_version ())
 

--- a/testsuite/miscellaneousfunctions.ml
+++ b/testsuite/miscellaneousfunctions.ml
@@ -25,10 +25,7 @@ let all op1 op2 exp =
   printf "%s\n" (M.get_formatted_str (M.max op1 op2));
   printf "%d\n" (M.get_exp op1);
   printf "%d\n" (M.get_exp (M.set_exp op1 exp));
-  printf "%s\n"
-    (match M.signbit op1 with
-    | M.Positive -> "Positive"
-    | M.Negative -> "Negative");
+  printf "%s\n" (if M.signbit op1 then "Positive" else "Negative");
   printf "%s\n" (M.get_formatted_str (M.copysign op1 op2));
   printf "%s\n" (M.get_version ())
 

--- a/testsuite/specialfunctions.ml
+++ b/testsuite/specialfunctions.ml
@@ -131,7 +131,10 @@ let all op1 op2 u =
   printf "%s %s\n" (M.get_formatted_str r) (rounding_to_string r);
   let r, s = M.lgamma op1 in
   printf "%s %s %s\n" (M.get_formatted_str r)
-    (match s with M.Positive -> "Positive" | M.Negative -> "Negative")
+    (match s with
+    | M.Positive -> "Positive"
+    | M.Negative -> "Negative"
+    | M.Zero -> "Zero")
     (rounding_to_string r);
   let r = M.digamma op1 in
   printf "%s %s\n" (M.get_formatted_str r) (rounding_to_string r);


### PR DESCRIPTION
MPFR encodes the "sign" of a number of multiple ways (see discussion). A simple binary value does not properly cover all the cases. This PR adds a third case: neither positive or negative.

Documentation and tests updated accordingly. This is a breaking change.