### PR TITLE
Add custom functions to allow hash and marshalling

### DIFF
--- a/src/mlmpfr.ml
+++ b/src/mlmpfr.ml
@@ -60,6 +60,9 @@ let mpfr_prec_min = mpfr_prec_min ()
 let mpfr_prec_max = mpfr_prec_max ()
 
 (* Initialization Functions *)
+external init_custom : unit -> unit = "mlmpfr_init_custom"
+let () = init_custom ()
+
 external set_default_prec : mpfr_prec_t -> unit = "caml_mpfr_set_default_prec"
 external get_default_prec : unit -> mpfr_prec_t = "caml_mpfr_get_default_prec"
 external get_prec : mpfr_float -> mpfr_prec_t = "caml_mpfr_get_prec"

--- a/src/mlmpfr_stubs.c
+++ b/src/mlmpfr_stubs.c
@@ -782,71 +782,72 @@ CAMLprim value caml_mpfr_total_order_p(value op1, value op2) {
 }
 
 static int custom_compare(value v1, value v2) {
-  return mpfr_cmp(MPFR_val(v1), MPFR_val(v2));
+  int r = mpfr_cmp(MPFR_val(v1), MPFR_val(v2));
+  return r;
 }
 
 static void custom_serialize(value v,
 			     uintnat *wsize_32,
 			     uintnat *wsize_64)
 {
-    mpfr_t *x = (mpfr_t *) Data_custom_val(v);
-    long sign = mpfr_signbit(*x) ? -1 : 1;
-    mpfr_prec_t prec = mpfr_get_prec(*x);
-    mpfr_exp_t exp = mpfr_get_exp(*x);
-    size_t nlimbs = (prec + GMP_NUMB_BITS - 1) / GMP_NUMB_BITS;
+  // unsafe between architecture where mpfr_t differs
+  mpfr_t *x = (mpfr_t *) Data_custom_val(v);
+  mpfr_sign_t sign = (*x)->_mpfr_sign;
+  mpfr_prec_t prec = (*x)->_mpfr_prec;
+  mpfr_exp_t exp = (*x)->_mpfr_exp;
+  size_t nlimbs = (prec + GMP_NUMB_BITS - 1) / GMP_NUMB_BITS;
 
-    mp_limb_t *limbs = (mp_limb_t *) (*x)->_mpfr_d;
+  mp_limb_t *limbs = (mp_limb_t *) (*x)->_mpfr_d;
 
-    caml_serialize_int_1((int64_t) sign);
-    caml_serialize_int_8((int64_t) prec);
-    caml_serialize_int_8((int64_t) exp);
-
-    for (size_t i = 0; i < nlimbs; i++) {
-        caml_serialize_int_8((int64_t) limbs[i]);
-    }
-    // does not allow exchange between 32 bits and 64 bits
-    *wsize_32 = *wsize_64 = sizeof(mpfr_t);
+  caml_serialize_int_4((int64_t) sign);
+  caml_serialize_int_8((int64_t) prec);
+  caml_serialize_int_8((int64_t) exp);
+  for (size_t i = 0; i < nlimbs; i++) {
+    caml_serialize_int_8((int64_t) limbs[i]);
+  }
+  *wsize_32 = *wsize_64 = sizeof(mpfr_t);
 }
 
 static uintnat custom_deserialize(void *dst)
 {
-    mpfr_t *x = (mpfr_t *) dst;
+  // unsafe between architecture where mpfr_t differs
+  mpfr_t *x = (mpfr_t *) dst;
 
-    long sign        = caml_deserialize_sint_1();
-    mpfr_prec_t prec = caml_deserialize_uint_8();
-    mpfr_exp_t exp   = caml_deserialize_sint_8();
-    size_t nlimbs = (prec + GMP_NUMB_BITS - 1) / GMP_NUMB_BITS;
+  mpfr_sign_t sign = caml_deserialize_sint_4();
+  mpfr_prec_t prec = caml_deserialize_uint_8();
+  mpfr_exp_t exp   = caml_deserialize_sint_8();
+  size_t nlimbs = (prec + GMP_NUMB_BITS - 1) / GMP_NUMB_BITS;
 
-    mpfr_init2(*x, prec);
+  mpfr_init2(*x, prec);
+  (*x)->_mpfr_sign = sign;
+  (*x)->_mpfr_exp  = exp;
 
-    (*x)->_mpfr_sign = sign;
-    (*x)->_mpfr_exp  = exp;
+  mp_limb_t *limbs = (mp_limb_t *) (*x)->_mpfr_d;
 
-    mp_limb_t *limbs = (mp_limb_t *) (*x)->_mpfr_d;
-
-    for (size_t i = 0; i < nlimbs; i++) {
-        limbs[i] = (mp_limb_t) caml_deserialize_uint_8();
-    }
-    return sizeof(mpfr_t);
+  for (size_t i = 0; i < nlimbs; i++) {
+    limbs[i] = (mp_limb_t) caml_deserialize_sint_8();
+  }
+  return sizeof(mpfr_t);
 }
 
 static intnat custom_hash(value v)
 {
-    mpfr_t *x = (mpfr_t *) Data_custom_val(v);
-    long sign = mpfr_signbit(*x) ? -1 : 1;
-    mpfr_prec_t prec = mpfr_get_prec(*x);
-    mpfr_exp_t exp = mpfr_get_exp(*x);
-    size_t nlimbs = (prec + GMP_NUMB_BITS - 1) / GMP_NUMB_BITS;
-    mp_limb_t *limbs = (mp_limb_t *) (*x)->_mpfr_d;
-    uint32_t h = 0;
+  // hash changes between architecture where mpfr_t differs
+  mpfr_t *x = (mpfr_t *) Data_custom_val(v);
+  long sign = (*x)->_mpfr_sign;
+  mpfr_prec_t prec = (*x)->_mpfr_prec;
+  mpfr_exp_t exp = (*x)->_mpfr_exp;
+  size_t nlimbs = (prec + GMP_NUMB_BITS - 1) / GMP_NUMB_BITS;
+  mp_limb_t *limbs = (mp_limb_t *) (*x)->_mpfr_d;
+  uint32_t h = 0;
 
-    caml_hash_mix_uint32(h, sign);
-    caml_hash_mix_int64(h, prec);
-    caml_hash_mix_int64(h, exp);
-    for (size_t i = 0; i < nlimbs; i++) {
-         caml_hash_mix_int64(h, limbs[i]);
-    }
-    return h;
+  h = caml_hash_mix_uint32(h, sign);
+  h = caml_hash_mix_int64(h, prec);
+  h = caml_hash_mix_int64(h, exp);
+  for (size_t i = 0; i < nlimbs; i++) {
+    h = caml_hash_mix_int64(h, limbs[i]);
+  }
+  return h;
 }
 
 /*********************/

--- a/src/mlmpfr_stubs.c
+++ b/src/mlmpfr_stubs.c
@@ -50,6 +50,11 @@ void base_in_range(value base) {
 /****************************/
 /* Initialization Functions */
 /****************************/
+CAMLprim value mlmpfr_init_custom()
+{
+    caml_register_custom_operations(&mpfr_ops);
+    return Val_unit;
+}
 
 CAMLprim value caml_mpfr_init2_opt(value prec) {
   CAMLparam1(prec);
@@ -778,6 +783,70 @@ CAMLprim value caml_mpfr_total_order_p(value op1, value op2) {
 
 static int custom_compare(value v1, value v2) {
   return mpfr_cmp(MPFR_val(v1), MPFR_val(v2));
+}
+
+static void custom_serialize(value v,
+			     uintnat *wsize_32,
+			     uintnat *wsize_64)
+{
+    mpfr_t *x = (mpfr_t *) Data_custom_val(v);
+    long sign = mpfr_signbit(*x) ? -1 : 1;
+    mpfr_prec_t prec = mpfr_get_prec(*x);
+    mpfr_exp_t exp = mpfr_get_exp(*x);
+    size_t nlimbs = (prec + GMP_NUMB_BITS - 1) / GMP_NUMB_BITS;
+
+    mp_limb_t *limbs = (mp_limb_t *) (*x)->_mpfr_d;
+
+    caml_serialize_int_1((int64_t) sign);
+    caml_serialize_int_8((int64_t) prec);
+    caml_serialize_int_8((int64_t) exp);
+
+    for (size_t i = 0; i < nlimbs; i++) {
+        caml_serialize_int_8((int64_t) limbs[i]);
+    }
+    // does not allow exchange between 32 bits and 64 bits
+    *wsize_32 = *wsize_64 = sizeof(mpfr_t);
+}
+
+static uintnat custom_deserialize(void *dst)
+{
+    mpfr_t *x = (mpfr_t *) dst;
+
+    long sign        = caml_deserialize_sint_1();
+    mpfr_prec_t prec = caml_deserialize_uint_8();
+    mpfr_exp_t exp   = caml_deserialize_sint_8();
+    size_t nlimbs = (prec + GMP_NUMB_BITS - 1) / GMP_NUMB_BITS;
+
+    mpfr_init2(*x, prec);
+
+    (*x)->_mpfr_sign = sign;
+    (*x)->_mpfr_exp  = exp;
+
+    mp_limb_t *limbs = (mp_limb_t *) (*x)->_mpfr_d;
+
+    for (size_t i = 0; i < nlimbs; i++) {
+        limbs[i] = (mp_limb_t) caml_deserialize_uint_8();
+    }
+    return sizeof(mpfr_t);
+}
+
+static intnat custom_hash(value v)
+{
+    mpfr_t *x = (mpfr_t *) Data_custom_val(v);
+    long sign = mpfr_signbit(*x) ? -1 : 1;
+    mpfr_prec_t prec = mpfr_get_prec(*x);
+    mpfr_exp_t exp = mpfr_get_exp(*x);
+    size_t nlimbs = (prec + GMP_NUMB_BITS - 1) / GMP_NUMB_BITS;
+    mp_limb_t *limbs = (mp_limb_t *) (*x)->_mpfr_d;
+    uint32_t h = 0;
+
+    caml_hash_mix_uint32(h, sign);
+    caml_hash_mix_int64(h, prec);
+    caml_hash_mix_int64(h, exp);
+    for (size_t i = 0; i < nlimbs; i++) {
+         caml_hash_mix_int64(h, limbs[i]);
+    }
+    return h;
 }
 
 /*********************/

--- a/src/mlmpfr_stubs.h
+++ b/src/mlmpfr_stubs.h
@@ -30,8 +30,11 @@
 #include <caml/fail.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
+#include <caml/intext.h>
+#include <caml/hash.h>
 #include <limits.h>
 #include <stdio.h>
+
 /* Prototypes for MPFR functions with FILE * parameters are provided only if
    <stdio.h> is included too (before mpfr.h) */
 #include <mpfr.h>
@@ -40,12 +43,18 @@ static int custom_compare(value, value);
 
 static void custom_finalize(value);
 
+static void custom_serialize(value, uintnat*, uintnat*);
+
+static uintnat custom_deserialize(void*);
+
+static intnat custom_hash(value v);
+
 static struct custom_operations mpfr_ops = {"https://github.com/thvnx/mlmpfr",
                                             custom_finalize,
                                             custom_compare,
-                                            custom_hash_default,
-                                            custom_serialize_default,
-                                            custom_deserialize_default,
+                                            custom_hash,
+                                            custom_serialize,
+                                            custom_deserialize,
 #ifndef custom_fixed_length_default
                                             custom_compare_ext_default};
 #else

--- a/testsuite/specialfunctions.ml
+++ b/testsuite/specialfunctions.ml
@@ -190,7 +190,19 @@ let all op1 op2 u =
   let m = s 100000 in
   let r = M.dot l m in
   printf "%s %s %d\n" (M.get_formatted_str r) (rounding_to_string r)
-    (List.length m)
+    (List.length m);
+  let op1' = Marshal.from_string (Marshal.to_string op1 []) 0 in
+  let op2' = Marshal.from_string (Marshal.to_string op2 []) 0 in
+  let h1 = Hashtbl.hash(op1) in
+  let h2 = Hashtbl.hash(op2) in
+  let h1' = Hashtbl.hash(op1') in
+  let h2' = Hashtbl.hash(op2') in
+  assert ((M.cmp op1 op1') = 0);
+  assert ((M.cmp op2 op2') = 0);
+  assert (op1 = op1');
+  assert (op2 = op2');
+  assert (h1 = h1' && h2 = h2');
+  assert ((h1 = h2) = (op1 = op2))
 
 let _ =
   all (M.make_from_float (1. /. 3.)) (M.make_from_float (1. /. 10.)) 3;


### PR DESCRIPTION

Add custom functions to allow hash and marshaling

WARNING: marshaling across architecture fails if mpfr_t internal changes. (the hash changes too).  An architecture independent marshaling is hard because mpfr does not provide robust float to string - string to float function. Only an import and export to file!

This is already better than nothing I think.